### PR TITLE
Asset :asset-path option, fixes #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.3.1
+
+- Added `:asset-path` option

--- a/build.boot
+++ b/build.boot
@@ -1,4 +1,5 @@
 (set-env!
+ :source-paths #{"src" "test"}
  :dependencies '[[org.clojure/clojure "1.6.0"     :scope "provided"]
                  [boot/core           "2.0.0"     :scope "provided"]
                  [adzerk/bootlaces    "0.1.10"    :scope "test"]

--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -39,10 +39,13 @@
             (client/connect ~url {:on-jsload #(~(or on-jsload '+))}))))
     (map pr-str) (interpose "\n") (apply str) (spit f)))
 
-(defn- send-changed! [pod changed]
+(defn- send-changed! [pod asset-path changed]
   (when-not (empty? changed)
     (pod/with-call-in pod
-      (adzerk.boot-reload.server/send-changed! ~(get-env :target-path) ~changed))))
+      (adzerk.boot-reload.server/send-changed!
+        ~(get-env :target-path)
+        ~asset-path
+        ~changed))))
 
 (defn- add-init!
   [in-file out-file]
@@ -64,7 +67,8 @@
 
   [i ip ADDR       str "The (optional) IP address for the websocket server to listen on."
    p port PORT     int "The (optional) port the websocket server listens on."
-   j on-jsload SYM sym "The (optional) callback to call when JS files are reloaded."]
+   j on-jsload SYM sym "The (optional) callback to call when JS files are reloaded."
+   a asset-path PATH str "The (optional) asset-path. This is removed from the start of reloaded urls."]
 
   (let [pod  (make-pod)
         src  (tmp-dir!)
@@ -82,6 +86,6 @@
             (add-init! in-file out-file)))
         (-> fileset (add-resource tmp) commit!))
       (with-post-wrap fileset
-        (send-changed! @pod (changed @prev fileset))
+        (send-changed! @pod asset-path (changed @prev fileset))
         (reset! prev fileset)))))
 

--- a/src/adzerk/boot_reload/server.clj
+++ b/src/adzerk/boot_reload/server.clj
@@ -12,7 +12,7 @@
 (defn web-path [proto rel-path tgt-path asset-path]
   (if-not (= "file:" proto)
     (if asset-path
-      (string/replace rel-path (re-pattern (str "^" asset-path "/")) "")
+      (string/replace rel-path (re-pattern (str "^" (string/replace asset-path #"^/" "") "/")) "")
       (str "/" rel-path))
     (.getCanonicalPath (io/file tgt-path rel-path))))
 

--- a/test/adzerk/boot_reload/server_test.clj
+++ b/test/adzerk/boot_reload/server_test.clj
@@ -1,0 +1,16 @@
+(ns adzerk.boot-reload.server-test
+  (:require [clojure.test :refer :all]
+            [adzerk.boot-reload.server :refer :all]))
+
+(deftest web-path-test
+  (testing "Basic"
+    (is (= "/js/out/saapas/core.js"
+           (web-path "http:" "js/out/saapas/core.js" "target" nil))))
+
+  (testing "Asset-path"
+    (is (= "js/out/saapas/core.js"
+           (web-path "http:" "public/js/out/saapas/core.js" nil "public")))
+
+    (is (= "public/js/out/saapas/core.js"
+           (web-path "http:" "public/js/out/saapas/core.js" nil "foobar")))
+    ))

--- a/test/adzerk/boot_reload/server_test.clj
+++ b/test/adzerk/boot_reload/server_test.clj
@@ -11,6 +11,9 @@
     (is (= "js/out/saapas/core.js"
            (web-path "http:" "public/js/out/saapas/core.js" nil "public")))
 
+    (is (= "js/out/saapas/core.js"
+           (web-path "http:" "public/js/out/saapas/core.js" nil "/public")))
+
     (is (= "public/js/out/saapas/core.js"
            (web-path "http:" "public/js/out/saapas/core.js" nil "foobar")))
     ))


### PR DESCRIPTION
Removes specified path from the start of reloaded URL

@borkdude Please test.

Notes:
- Without asset-path rel-path is prepended with "/", I'm not sure if this is a good idea/required?
- Should url be prepended with "/" when asset-path is used?