### PR TITLE
Fix for changed-href?

### DIFF
--- a/src/adzerk/boot_reload/reload.cljs
+++ b/src/adzerk/boot_reload/reload.cljs
@@ -21,7 +21,7 @@
   (when href-or-uri
     (let [path (normalize-href-or-uri href-or-uri)]
       (when (not-empty (filter #(ends-with? (normalize-href-or-uri %) path) changed))
-        path))))
+        (guri/parse path)))))
 
 (defn- reload-css [changed]
   (let [sheets (.. js/document -styleSheets)]


### PR DESCRIPTION
All functions that use changed-href? expect a goog.Uri. instance where
they can call .makeUnique on.

This fixes:
- reload-css
- reload-img
- reload-html