### PR TITLE
Allows overriding domain name sent to client in write-cljs!

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -1,8 +1,10 @@
 (ns adzerk.boot-reload
   {:boot/export-tasks true}
   (:require
+   [boot.core          :as b]
    [clojure.java.io    :as io]
    [clojure.set        :as set]
+   [clojure.string     :as string]
    [boot.pod           :as pod]
    [boot.file          :as file]
    [boot.util          :as util]
@@ -21,10 +23,10 @@
          (sort-by :dependency-order)
          (map tmp-path))))
 
-(defn- start-server [pod {:keys [ip port] :as opts}]
+(defn- start-server [pod {:keys [ip port] :as opts} domain]
   (let [{:keys [ip port]}
         (pod/with-call-in pod (adzerk.boot-reload.server/start ~opts))
-        host (if-not (= ip "0.0.0.0") ip "localhost")]
+        host (if-not (string/blank? domain) domain (if-not (= ip "0.0.0.0") ip "localhost"))]
     (util/with-let [url (format "ws://%s:%d" host port)]
       (util/info "<< started reload server on %s >>\n" url))))
 
@@ -75,6 +77,7 @@
   [b ids BUILD_IDS #{str} "Only inject reloading into these builds (= .cljs.edn files)"
    i ip ADDR         str  "The (optional) IP address for the websocket server to listen on."
    p port PORT       int  "The (optional) port the websocket server listens on."
+   d domain DOMAIN   str  "The (optional) server domain name to pass through requests."
    j on-jsload SYM   sym  "The (optional) callback to call when JS files are reloaded."
    a asset-path PATH str  "The (optional) asset-path. This is removed from the start of reloaded urls."]
 
@@ -82,9 +85,10 @@
         src  (tmp-dir!)
         tmp  (tmp-dir!)
         prev (atom nil)
-        out  (doto (io/file src "adzerk" "boot_reload.cljs") io/make-parents)]
+        out  (doto (io/file src "adzerk" "boot_reload.cljs") io/make-parents)
+        url  (start-server @pod {:ip ip :port port} domain)]
     (set-env! :source-paths #(conj % (.getPath src)))
-    (write-cljs! out (start-server @pod {:ip ip :port port}) on-jsload)
+    (write-cljs! out url on-jsload)
     (comp
       (with-pre-wrap fileset
         (doseq [f (relevant-cljs-edn fileset ids)]
@@ -96,4 +100,3 @@
       (with-post-wrap fileset
         (send-changed! @pod asset-path (changed @prev fileset))
         (reset! prev fileset)))))
-


### PR DESCRIPTION
Locally, I develop on a VM with ssh and sftp-- this makes it hard to connect to the websocket server via ws://localhost. This patch allows me to configure reload to accept a hostname via the -d flag and connect without bringing up some strange VPN mess.

Additionally adds boot.core as b to fix build broken from 5a9042f