### PR TITLE
Guard container removal

### DIFF
--- a/src/adzerk/boot_reload/display.cljs
+++ b/src/adzerk/boot_reload/display.cljs
@@ -118,7 +118,9 @@
 (defn display [messages opts]
   (swap! current-container
          (fn [container]
-           (when container (remove-container! container))
+           (when container
+             (try (remove-container! container)
+                  (catch js/Error _)))
            (let [id (gen-id)]
              (insert-container! id messages)
              id))))


### PR DESCRIPTION
- Since boot reload doesn't own the DOM it can't assume that the
  container will exist.