### PR TITLE
Improve HUD visibility

### DIFF
--- a/src/adzerk/boot_reload/display.cljs
+++ b/src/adzerk/boot_reload/display.cljs
@@ -59,7 +59,8 @@
                        :position "fixed"
                        :left "0px"
                        :right "0px"
-                       :bottom "0px"]
+                       :bottom "0px"
+                       :z-index "999999"]
            :hide      [:opacity "0"
                        :bottom "-100px"]}]
     {:style (apply concat (map s types))}))


### PR DESCRIPTION
While developing a project, the HUD was appearing behind another absolute positioned element in my application, preventing me from reading the warnings and errors.

This patch gives the HUD a z-index of 999999, which is reasonably higher than will appear in most software.  The user can still set a higher value in their software if they do want one of their elements to appear in front of the development HUD.