### PR TITLE
add asset-host option; closes #51

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -7,7 +7,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.4.2")
+(def +version+ "0.4.3-SNAPSHOT")
 
 (bootlaces! +version+)
 

--- a/src/adzerk/boot_reload/reload.cljs
+++ b/src/adzerk/boot_reload/reload.cljs
@@ -64,9 +64,10 @@
   (.groupEnd js/console))
 
 (defn reload [changed opts]
-  (group-log "Reload" changed)
-  (doto changed
-    (reload-js opts)
-    reload-html
-    reload-css
-    reload-img))
+  (let [changed* (map #(str (:asset-host opts) %) changed)]
+    (group-log "Reload" changed*)
+    (doto changed*
+      (reload-js opts)
+      reload-html
+      reload-css
+      reload-img)))


### PR DESCRIPTION
@Deraen your reasons for a task option made sense so I went with that.

Shouldn't change anything for users not specifying `:asset-host` option.

Also changed option docstrings slightly (moved `(optional)` to the end) and rearranged based on what they're related to.