### PR TITLE
Deterministic script reload order.

### DIFF
--- a/src/adzerk/boot_reload/reload.cljs
+++ b/src/adzerk/boot_reload/reload.cljs
@@ -41,10 +41,10 @@
                            :or {on-jsload identity}}]
   (let [js-files (filter #(ends-with? % ".js") changed)]
     (when (seq js-files)
-      (-> #(-> % guri/parse .makeUnique jsloader/load)
+      (-> #(-> % guri/parse .makeUnique)
         (map js-files)
         clj->js
-        deferred-list/gatherResults
+        (jsloader/loadMany)
         (.addCallbacks
           (fn [& _] (on-jsload))
           (fn [e] (.error js/console "Load failed:" (.-message e)))))


### PR DESCRIPTION
This changes script reloading to use [loadMany](http://google.github.io/closure-library/api/namespace_goog_net_jsloader.html#loadMany), which guarantees the order of loading.  Previously, there was a data race between the changed files.  This resulted in occasionally a script with a `require` dependency being reloaded before the dependency was reloaded.

Since the list of changed files will be in the correct order based on dependencies, I think this will work for all cases.