### PR TITLE
Add a toggle for the HUD

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -97,7 +97,8 @@
    j on-jsload SYM     sym "The callback to call when JS files are reloaded. (optional)"
    _ asset-host HOST   str "The asset-host where to load files from. Defaults to host of opened page. (optional)"
    a asset-path PATH   str "The asset-path. This is removed from the start of reloaded urls. (optional)"
-   o open-file COMMAND str "The command to run when warning or exception is clicked on HUD. Passed to format. (optional)"]
+   o open-file COMMAND str "The command to run when warning or exception is clicked on HUD. Passed to format. (optional)"
+   v disabled-hud      bool "Toggle to disable HUD. Defaults to false (visible)."]
 
   (let [pod  (make-pod)
         src  (tmp-dir!)
@@ -123,7 +124,7 @@
               fileset (try
                         (next-task fileset)
                         (catch Exception e
-                          (if (= :boot-cljs (:from (ex-data e)))
+                          (if (and (= :boot-cljs (:from (ex-data e))) (not disabled-hud))
                             (send-visual! @pod {:exception (merge {:message (.getMessage e)}
                                                                   (ex-data e))}))
                           (throw e)))]
@@ -133,7 +134,8 @@
                                   (map b/tmp-path)
                                   (map(fn [x] (clojure.string/replace x #"\.cljs\.edn$" ".js")))
                                   set)]
-            (send-visual! @pod {:warnings warnings})
+            (if-not disabled-hud
+              (send-visual! @pod {:warnings warnings}))
             ; Only send changed files when there are no warnings
             ; As prev is updated only when changes are sent, changes are queued untill they can be sent
             (when (empty? warnings)


### PR DESCRIPTION
To fix one of the red screens we're getting with `boot-react-native` [(general issue here)](https://github.com/mjmeintjes/boot-react-native/issues/10) we need a toggle for the HUD's in boot-reload. It's due to the assumption that an app has a DOM, which is not the case in the context of React Native and thus it will throw an error on trying to write to the DOM.