### PR TITLE
Fix/react native

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -98,7 +98,7 @@
    _ asset-host HOST   str "The asset-host where to load files from. Defaults to host of opened page. (optional)"
    a asset-path PATH   str "The asset-path. This is removed from the start of reloaded urls. (optional)"
    o open-file COMMAND str "The command to run when warning or exception is clicked on HUD. Passed to format. (optional)"
-   v disabled-hud      bool "Toggle to disable HUD. Defaults to false (visible)."]
+   v disable-hud      bool "Toggle to disable HUD. Defaults to false (visible)."]
 
   (let [pod  (make-pod)
         src  (tmp-dir!)
@@ -124,7 +124,7 @@
               fileset (try
                         (next-task fileset)
                         (catch Exception e
-                          (if (and (= :boot-cljs (:from (ex-data e))) (not disabled-hud))
+                          (if (and (= :boot-cljs (:from (ex-data e))) (not disable-hud))
                             (send-visual! @pod {:exception (merge {:message (.getMessage e)}
                                                                   (ex-data e))}))
                           (throw e)))]
@@ -134,7 +134,7 @@
                                   (map b/tmp-path)
                                   (map(fn [x] (clojure.string/replace x #"\.cljs\.edn$" ".js")))
                                   set)]
-            (if-not disabled-hud
+            (if-not disable-hud
               (send-visual! @pod {:warnings warnings}))
             ; Only send changed files when there are no warnings
             ; As prev is updated only when changes are sent, changes are queued untill they can be sent

--- a/src/adzerk/boot_reload/client.cljs
+++ b/src/adzerk/boot_reload/client.cljs
@@ -24,7 +24,8 @@
 
 (defmethod handle :visual
   [state opts]
-  (d/display state opts))
+  (when (rl/has-dom?)
+    (d/display state opts)))
 
 (defn connect [url & [opts]]
   (when-not (alive?)

--- a/src/adzerk/boot_reload/reload.cljs
+++ b/src/adzerk/boot_reload/reload.cljs
@@ -63,11 +63,19 @@
   (doseq [t things-to-log] (.log js/console t))
   (.groupEnd js/console))
 
+(defn has-dom?
+  "Perform heuristics to check if a non-shimmed DOM is available"
+  []
+  (and (exists? js/window)
+       (exists? js/window.document)
+       (exists? js/window.document.documentURI)))
+
 (defn reload [changed opts]
   (let [changed* (map #(str (:asset-host opts) %) changed)]
     (group-log "Reload" changed*)
-    (doto changed*
-      (reload-js opts)
-      reload-html
-      reload-css
-      reload-img)))
+    (reload-js changed* opts)
+    (when (has-dom?)
+      (doto changed*
+        reload-html
+        reload-css
+        reload-img))))


### PR DESCRIPTION
This PR makes boot-reload work from react-native (especially https://github.com/mjmeintjes/boot-react-native/) and other non-browser related. Also renames option to `disable-hud` (though this flag is not needed in a non-browser environment anymore). For details, please see individual commit messages.