### PR TITLE
Default to connecting to browser's current host

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -44,7 +44,7 @@
                 protocol    (.getScheme passed-uri)
                 host        (or ~ws-host (.-hostname (.-location js/window)))
                 port        (.getPort passed-uri)
-                url         (str proto "://" host ":" port)]
+                url         (str protocol "://" host ":" port)]
             (client/connect url {:on-jsload #(~(or on-jsload '+))
                                  :asset-host ~asset-host}))))
     (map pr-str) (interpose "\n") (apply str) (spit f)))

--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -37,15 +37,10 @@
          ((ns adzerk.boot-reload
             (:require
              [adzerk.boot-reload.client :as client]
-             ~@(when on-jsload [(symbol (namespace on-jsload))]))
-            (:import goog.Uri))
-          (let [passed-uri  (Uri. ~url)
-                protocol    (.getScheme passed-uri)
-                host        (or ~ws-host (.-hostname (.-location js/window)))
-                port        (.getPort passed-uri)
-                url         (str protocol "://" host ":" port)]
-            (client/connect url {:on-jsload #(~(or on-jsload '+))
-                                 :asset-host ~asset-host}))))
+             ~@(when on-jsload [(symbol (namespace on-jsload))])))
+          (client/connect ~url {:on-jsload #(~(or on-jsload '+))
+                                :asset-host ~asset-host
+                                :ws-host ~ws-host})))
     (map pr-str) (interpose "\n") (apply str) (spit f)))
 
 (defn- send-visual! [pod messages]

--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -27,18 +27,26 @@
   (let [{:keys [ip port]} (pod/with-call-in pod (adzerk.boot-reload.server/start ~opts))
         host              (cond ws-host ws-host (= ip "0.0.0.0") "localhost" :else ip)
         proto             (if secure? "wss" "ws")]
-    (util/with-let [url (format "%s://%s:%d" proto host port)]
-      (util/info "Starting reload server on %s\n" url))))
+    [(util/with-let [url (format "%s://%s:%d" proto host port)]
+       (util/info "Starting reload server on %s\n" url))
+     ws-host]))
 
-(defn- write-cljs! [f url on-jsload asset-host]
-  (util/info "Writing %s...\n" (.getName f))
+(defn- write-cljs! [f url ws-host on-jsload asset-host]
+  (util/info "Writing %s to connect to %s...\n" (.getName f)
+             (if ws-host url "default websocket host"))
   (->> (template
          ((ns adzerk.boot-reload
             (:require
              [adzerk.boot-reload.client :as client]
-             ~@(when on-jsload [(symbol (namespace on-jsload))])))
-          (client/connect ~url {:on-jsload #(~(or on-jsload '+))
-                                :asset-host ~asset-host})))
+             ~@(when on-jsload [(symbol (namespace on-jsload))]))
+            (:import goog.Uri))
+          (let [passed-uri  (Uri. ~url)
+                protocol    (.getScheme passed-uri)
+                host        (or ~ws-host (.-hostname (.-location js/window)))
+                port        (.getPort passed-uri)
+                url         (str proto "://" host ":" port)]
+            (client/connect url {:on-jsload #(~(or on-jsload '+))
+                                 :asset-host ~asset-host}))))
     (map pr-str) (interpose "\n") (apply str) (spit f)))
 
 (defn- send-visual! [pod messages]
@@ -91,7 +99,7 @@
    ;; Websocket Server
    i ip ADDR         str  "The IP address for the websocket server to listen on. (optional)"
    p port PORT       int  "The port the websocket server listens on. (optional)"
-   w ws-host WSADDR  str  "The websocket host address to pass to clients. (optional)"
+   w ws-host WSADDR  str  "The websocket host clients connect to. Defaults to current host. (optional)"
    s secure          bool "Flag to indicate whether the client should connect via wss. Defaults to false."
    ;; Other Configuration
    j on-jsload SYM     sym "The callback to call when JS files are reloaded. (optional)"
@@ -106,10 +114,10 @@
         prev-pre (atom nil)
         prev (atom nil)
         out  (doto (io/file src "adzerk" "boot_reload.cljs") io/make-parents)
-        url  (start-server @pod {:ip ip :port port :ws-host ws-host :secure? secure
-                                 :open-file open-file})]
+        [url ws-host] (start-server @pod {:ip ip :port port :ws-host ws-host :secure? secure
+                                    :open-file open-file})]
     (set-env! :source-paths #(conj % (.getPath src)))
-    (write-cljs! out url on-jsload asset-host)
+    (write-cljs! out url ws-host on-jsload asset-host)
     (fn [next-task]
       (fn [fileset]
         (pod/with-call-in @pod

--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -27,9 +27,8 @@
   (let [{:keys [ip port]} (pod/with-call-in pod (adzerk.boot-reload.server/start ~opts))
         host              (cond ws-host ws-host (= ip "0.0.0.0") "localhost" :else ip)
         proto             (if secure? "wss" "ws")]
-    [(util/with-let [url (format "%s://%s:%d" proto host port)]
-       (util/info "Starting reload server on %s\n" url))
-     ws-host]))
+    (util/with-let [url (format "%s://%s:%d" proto host port)]
+      (util/info "Starting reload server on %s\n" url))))
 
 (defn- write-cljs! [f url ws-host on-jsload asset-host]
   (util/info "Writing %s to connect to %s...\n" (.getName f)
@@ -114,8 +113,8 @@
         prev-pre (atom nil)
         prev (atom nil)
         out  (doto (io/file src "adzerk" "boot_reload.cljs") io/make-parents)
-        [url ws-host] (start-server @pod {:ip ip :port port :ws-host ws-host :secure? secure
-                                    :open-file open-file})]
+        url  (start-server @pod {:ip ip :port port :ws-host ws-host :secure? secure
+                                 :open-file open-file})]
     (set-env! :source-paths #(conj % (.getPath src)))
     (write-cljs! out url ws-host on-jsload asset-host)
     (fn [next-task]


### PR DESCRIPTION
Previously, boot-reload would just assume its client should connect to a websocket server on `localhost` if nothing was specified in the `:ws-host` option.

A better default in that scenario is to connect to the browser's current host. This allows for users to, for example, establish the reload workflow on apps running on VMs, or apps being accessed through the host's external IP, etc. The `:ws-host` option is maintained and will override this default mechanism, if specified.