### PR TITLE
Add output-dir option

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -49,12 +49,13 @@
       (adzerk.boot-reload.server/send-visual!
         ~messages))))
 
-(defn- send-changed! [pod asset-path changed]
+(defn- send-changed! [pod asset-path cljs-asset-path changed]
   (when-not (empty? changed)
     (pod/with-call-in pod
       (adzerk.boot-reload.server/send-changed!
-        ~(get-env :target-path)
-        ~asset-path
+       {:target-path ~(get-env :target-path)
+        :asset-path ~asset-path
+        :cljs-asset-path ~cljs-asset-path}
         ~changed))))
 
 (defn- add-init!
@@ -98,7 +99,8 @@
    ;; Other Configuration
    j on-jsload SYM     sym "The callback to call when JS files are reloaded. (optional)"
    _ asset-host HOST   str "The asset-host where to load files from. Defaults to host of opened page. (optional)"
-   a asset-path PATH   str "The asset-path. This is removed from the start of reloaded urls. (optional)"
+   a asset-path PATH   str "Sets the output directory for temporary files used during compilation. (optional)"
+   c cljs-asset-path PATH str "The actual asset path. This is added to the start of reloaded urls. (optional)"
    o open-file COMMAND str "The command to run when warning or exception is clicked on HUD. Passed to format. (optional)"
    v disable-hud      bool "Toggle to disable HUD. Defaults to false (visible)."]
 
@@ -141,6 +143,6 @@
             ; Only send changed files when there are no warnings
             ; As prev is updated only when changes are sent, changes are queued untill they can be sent
             (when (empty? warnings)
-              (send-changed! @pod asset-path (changed @prev fileset static-files))
+              (send-changed! @pod asset-path cljs-asset-path (changed @prev fileset static-files))
               (reset! prev fileset))
             fileset))))))

--- a/test/adzerk/boot_reload/server_test.clj
+++ b/test/adzerk/boot_reload/server_test.clj
@@ -4,16 +4,22 @@
 
 (deftest web-path-test
   (testing "Basic"
-    (is (= "/js/out/saapas/core.js"
-           (web-path "http:" "js/out/saapas/core.js" "target" nil))))
+    (is (= "js/out/saapas/core.js"
+           (web-path {:protocol "http:" :target-path "target"} "js/out/saapas/core.js"))))
 
   (testing "Asset-path"
     (is (= "js/out/saapas/core.js"
-           (web-path "http:" "public/js/out/saapas/core.js" nil "public")))
+           (web-path {:protocol "http:" :asset-path "public"} "public/js/out/saapas/core.js")))
 
     (is (= "js/out/saapas/core.js"
-           (web-path "http:" "public/js/out/saapas/core.js" nil "/public")))
+           (web-path {:protocol "http:" :asset-path "/public"} "public/js/out/saapas/core.js")))
 
     (is (= "public/js/out/saapas/core.js"
-           (web-path "http:" "public/js/out/saapas/core.js" nil "foobar")))
-    ))
+           (web-path {:protocol "http:" :asset-path "foobar"} "public/js/out/saapas/core.js"))))
+
+  (testing "Cljs-asset-path"
+    (is (= "js/saapas.out/saapas/core.js"
+           (web-path {:protocol "http:"
+                      :asset-path "resources/public/js/saapas.out"
+                      :cljs-asset-path "js/saapas.out"}
+                     "resources/public/js/saapas.out/saapas/core.js")))))


### PR DESCRIPTION
The old asset-path option had the opposite behavior of the same option
in the clojurescript compiler.  It was performing a role similar to
clojurescript's output-dir, and there was no way to get the expected
asset-path behaviour.

See https://github.com/clojure/clojurescript/wiki/Compiler-Options

This commit renames the old asset-path to output-dir, and adds a true
asset-path option.