### PR TITLE
Fixes Windows support

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
   :dependencies '[[org.clojure/clojure "1.7.0"     :scope "provided"]
                   [boot/core           "2.5.5"     :scope "provided"]
                   [http-kit            "2.1.19"    :scope "test"]
-                  [adzerk/boot-test    "1.0.7"     :scope "test"]])
+                  [adzerk/boot-test    "1.1.0"     :scope "test"]])
 
 (require '[adzerk.boot-test :refer [test]])
 

--- a/src/adzerk/boot_reload/server.clj
+++ b/src/adzerk/boot_reload/server.clj
@@ -16,7 +16,9 @@
 (defn web-path
   ([rel-path] (web-path {} rel-path))
   ([opts rel-path]
-   (let [{:keys [protocol target-path asset-path cljs-asset-path]} opts]
+   ; windows fix, convert \ characters to / in rel-path
+   (let [rel-path (string/replace rel-path #"\\" "/")
+         {:keys [protocol target-path asset-path cljs-asset-path]} opts]
      (if (= "file:" protocol)
        (.getCanonicalPath (io/file target-path rel-path))
        (str

--- a/test/adzerk/boot_reload/server_test.clj
+++ b/test/adzerk/boot_reload/server_test.clj
@@ -22,4 +22,11 @@
            (web-path {:protocol "http:"
                       :asset-path "resources/public/js/saapas.out"
                       :cljs-asset-path "js/saapas.out"}
-                     "resources/public/js/saapas.out/saapas/core.js")))))
+                     "resources/public/js/saapas.out/saapas/core.js"))))
+  
+  (testing "windows style paths"
+    (is (= "js/saapas.out/saapas/core.js"
+           (web-path {:protocol "http:"
+                      :asset-path "resources/public/js/saapas.out"
+                      :cljs-asset-path "js/saapas.out"}
+                     "resources\\public\\js\\saapas.out\\saapas\\core.js")))))


### PR DESCRIPTION
Fixes a problem where Windows style paths were reported via the websocket connection to the browser with backslashes. This essentially broke the reloading mechanism since in the Internet forward slashes are used as path separators.