### PR TITLE
make sure slash is prepended if no cljs-asset-host

### DIFF
--- a/src/adzerk/boot_reload/server.clj
+++ b/src/adzerk/boot_reload/server.clj
@@ -22,7 +22,7 @@
      (if (= "file:" protocol)
        (.getCanonicalPath (io/file target-path rel-path))
        (str
-        (if cljs-asset-path (str cljs-asset-path "/") "")
+        cljs-asset-path "/"
         (string/replace rel-path
                         (re-pattern (str "^" (string/replace (or asset-path "") #"^/" "") "/"))
                         ""))))))

--- a/test/adzerk/boot_reload/server_test.clj
+++ b/test/adzerk/boot_reload/server_test.clj
@@ -3,27 +3,27 @@
             [adzerk.boot-reload.server :refer :all]))
 
 (deftest web-path-test
-  (testing "Basic"
-    (is (= "js/out/saapas/core.js"
+  (testing "basic"
+    (is (= "/js/out/saapas/core.js"
            (web-path {:protocol "http:" :target-path "target"} "js/out/saapas/core.js"))))
 
-  (testing "Asset-path"
-    (is (= "js/out/saapas/core.js"
+  (testing "asset-path"
+    (is (= "/js/out/saapas/core.js"
            (web-path {:protocol "http:" :asset-path "public"} "public/js/out/saapas/core.js")))
 
-    (is (= "js/out/saapas/core.js"
+    (is (= "/js/out/saapas/core.js"
            (web-path {:protocol "http:" :asset-path "/public"} "public/js/out/saapas/core.js")))
 
-    (is (= "public/js/out/saapas/core.js"
+    (is (= "/public/js/out/saapas/core.js"
            (web-path {:protocol "http:" :asset-path "foobar"} "public/js/out/saapas/core.js"))))
 
-  (testing "Cljs-asset-path"
+  (testing "cljs-asset-path"
     (is (= "js/saapas.out/saapas/core.js"
            (web-path {:protocol "http:"
                       :asset-path "resources/public/js/saapas.out"
                       :cljs-asset-path "js/saapas.out"}
                      "resources/public/js/saapas.out/saapas/core.js"))))
-  
+
   (testing "windows style paths"
     (is (= "js/saapas.out/saapas/core.js"
            (web-path {:protocol "http:"


### PR DESCRIPTION
addresses https://github.com/adzerk-oss/boot-reload/pull/65#discussion_r68249725 — this broke reloading on pushState routes for me since the previously prepended slash was no longer prepended.

Open to discussion if this change is in line with #65.