### PR TITLE
Shutdown httpkit server on task cleanup

### DIFF
--- a/src/adzerk/boot_reload.clj
+++ b/src/adzerk/boot_reload.clj
@@ -126,6 +126,7 @@
                                  :open-file open-file})]
     (set-env! :source-paths #(conj % (.getPath src)))
     (write-cljs! out ns url ws-host on-jsload asset-host)
+    (b/cleanup (pod/with-call-in @pod (adzerk.boot-reload.server/stop)))
     (fn [next-task]
       (fn [fileset]
         (pod/with-call-in @pod

--- a/src/adzerk/boot_reload/server.clj
+++ b/src/adzerk/boot_reload/server.clj
@@ -9,6 +9,7 @@
 
 (def options (atom {:open-file nil}))
 (def clients (atom {}))
+(def stop-fn (atom nil))
 
 (defn set-options [opts]
   (reset! options opts))
@@ -66,5 +67,12 @@
 
 (defn start
   [{:keys [ip port] :as opts}]
-  (let [o {:ip (or ip "0.0.0.0") :port (or port 0)}]
-    (assoc o :port (-> (http/run-server handler o) meta :local-port))))
+  (let [o {:ip (or ip "0.0.0.0") :port (or port 0)}
+        stop-fn* (http/run-server handler o)]
+    (reset! stop-fn stop-fn*)
+    (assoc o :port (-> stop-fn* meta :local-port))))
+
+(defn stop []
+  (when @stop-fn
+    (@stop-fn)
+    (reset! stop-fn nil)))


### PR DESCRIPTION
When running boot-reload from a repl, successive runs leave running servers in the background, which means increasing resource usage, and potential hard-to-diagnose port conflicts.