### PR TITLE
Work in env without window.location

### DIFF
--- a/src/adzerk/boot_reload/client.cljs
+++ b/src/adzerk/boot_reload/client.cljs
@@ -21,7 +21,7 @@
 (defn resolve-url [url ws-host]
   (let [passed-uri (Uri. url)
         protocol   (.getScheme passed-uri)
-        hostname   (.-hostname (.-location js/window))
+        hostname   (some-> js/window .-location .-hostname)
         host       (cond
                      ws-host ws-host
                      (seq hostname) hostname

--- a/src/adzerk/boot_reload/reload.cljs
+++ b/src/adzerk/boot_reload/reload.cljs
@@ -77,7 +77,7 @@
 (defn reload [changed opts]
   (let [changed* (->> changed
                       (map (fn [{:keys [canonical-path web-path]}]
-                             (if (= "file:" (.. js/window -location -protocol))
+                             (if (= "file:" (some-> js/window .-location .-protocol))
                                canonical-path
                                web-path)))
                       ;; This should probably be empty if serving from file-system


### PR DESCRIPTION
Environments like React Native don't have a window.location. In such an
environment, boot-reload fails because window.location.hostname or
.protocol does not exist. Use some-> to avoid these exceptions.