### PR TITLE
Making popup overflow: hidden to remove scrollbars

### DIFF
--- a/src/adzerk/boot_reload/display.cljs
+++ b/src/adzerk/boot_reload/display.cljs
@@ -53,7 +53,7 @@
            :pad       [:padding "12px"]
            :container [:color "black"
                        :max-height "320px"
-                       :overflow "scroll"
+                       :overflow "hidden"
                        :transition (str transition-duration "ms")
                        :font-family "sans-serif"
                        :position "fixed"

--- a/src/adzerk/boot_reload/display.cljs
+++ b/src/adzerk/boot_reload/display.cljs
@@ -53,7 +53,7 @@
            :pad       [:padding "12px"]
            :container [:color "black"
                        :max-height "320px"
-                       :overflow "hidden"
+                       :overflow "auto"
                        :transition (str transition-duration "ms")
                        :font-family "sans-serif"
                        :position "fixed"


### PR DESCRIPTION
The horizontal and vertical scrollbars on Chrome at least are rather ugly.