### PR TITLE
Fix compatibility with ClojureScript 1.10.741 and up

### DIFF
--- a/src/adzerk/boot_reload/client.cljs
+++ b/src/adzerk/boot_reload/client.cljs
@@ -48,7 +48,7 @@
   ([url] (connect url nil))
   ([url opts]
    (when (and (not (alive?))
-              (some? goog/dependencies_))
+              goog/DEPENDENCIES_ENABLED)
      (let [conn (ws/websocket-connection)]
        (patch-goog-base!)
        (reset! ws-conn conn)

--- a/src/adzerk/boot_reload/websocket.cljs
+++ b/src/adzerk/boot_reload/websocket.cljs
@@ -20,7 +20,8 @@
   ([auto-reconnect?]
      (websocket-connection auto-reconnect? nil))
   ([auto-reconnect? next-reconnect-fn]
-     (goog.net.WebSocket. auto-reconnect? next-reconnect-fn)))
+     (goog.net.WebSocket. #js {:autoReconnect auto-reconnect?
+                               :getNextReconnect next-reconnect-fn})))
 
 (extend-type goog.net.WebSocket
   IWebSocket


### PR DESCRIPTION
ClojureScript 1.10.741 and up depend on Closure Library `0.0-20191016-6ae1f72f`, which has some API changes that break boot-reload. This fixes the obvious ones:

- `goog.net.WebSocket` now expects a parameter object.

- `goog.dependencies_` no longer exists, so the reload client was never connecting. It seems like `goog.DEPENDENCIES_ENABLED` is a reasonable replacement that should also be false in adv compilation.

It's possible there's more. I've only done a basic test with `boot-cljs` and `boot-less`, with reloads now working for both.